### PR TITLE
Fixes race condition with unending stream

### DIFF
--- a/jarbas_stt_plugin_vosk/__init__.py
+++ b/jarbas_stt_plugin_vosk/__init__.py
@@ -31,27 +31,32 @@ class VoskKaldiStreamThread(StreamThread):
         self.kaldi = kaldi
         self.verbose = verbose
         self.previous_partial = ""
+        self.running = True
 
     def handle_audio_stream(self, audio, language):
         for a in audio:
-            data = np.frombuffer(a, np.int16)
-            if self.kaldi.AcceptWaveform(data):
-                res = self.kaldi.Result()
-                res = json.loads(res)
-                self.text = res["text"]
-            else:
-                res = self.kaldi.PartialResult()
-                res = json.loads(res)
-                self.text = res["partial"]
-        if self.verbose:
-            if self.previous_partial != self.text:
-                LOG.info("Partial Transcription: " + self.text)
-        self.previous_partial = self.text
+            if self.running:
+                data = np.frombuffer(a, np.int16)
+                if self.kaldi.AcceptWaveform(data):
+                    res = self.kaldi.Result()
+                    res = json.loads(res)
+                    self.text = res["text"]
+                else:
+                    res = self.kaldi.PartialResult()
+                    res = json.loads(res)
+                    self.text = res["partial"]
+                if self.verbose:
+                    if self.previous_partial != self.text:
+                        LOG.info("Partial Transcription: " + self.text)
+                self.previous_partial = self.text
 
         return self.text
 
     def finalize(self):
+        self.running = False
         if self.previous_partial:
+            if self.verbose:
+                LOG.info("Finalizing stream")
             self.kaldi.FinalResult()
             self.previous_partial = ""
 


### PR DESCRIPTION
If finalizing the stream before the Queue is empty or if an element is added to the Queue before the StreamingSTT sets the stream to None, a fatal error in vosk might occur as the plugin tries to pass audio data to a closed KaldiRecognizer.

I experienced it when using the plugin with a custom speech client that receives audio from a websocket stream.

This is not an issue with the default mycroft speech client as it stops recording and feeding the stream after an end-of-speak, so it might not be of interest.
