### PR TITLE
fix: drop deprecated import

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,3 @@
 vosk
 ovos-plugin-manager>=0.0.1,<1.0.0
-ovos_skill_installer
 SpeechRecognition>=3.8.1


### PR DESCRIPTION
https://github.com/OpenVoiceOS/ovos_skill_installer has been archived for a LONG time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for downloading and extracting files from URLs, enhancing model management capabilities.
	- Added functionality to handle tar and zip file downloads and extractions.

- **Chores**
	- Removed the `ovos_skill_installer` dependency from requirements, streamlining the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->